### PR TITLE
Create delta and fix some spelling mistakes

### DIFF
--- a/config/availabilities.mdx
+++ b/config/availabilities.mdx
@@ -9,7 +9,7 @@ Availabilities are used in Common Fate to inform the policy engine what **role**
 
 ## Creating an Availability
 
-There are availabilies for each of the supported resources in Common Fate.
+There are availabilities for each of the supported resources in Common Fate.
 
 Below is an example of a GCP Availability:
 

--- a/config/selectors.mdx
+++ b/config/selectors.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Selectors"
-description: "This expains how to make Selectors to be used in Common Fate."
+description: "This explains how to make Selectors to be used in Common Fate."
 ---
 
 ## What are Selectors?

--- a/config/terraform.mdx
+++ b/config/terraform.mdx
@@ -28,7 +28,7 @@ This guide will walk you through setting up the `commonfate` Terraform provider.
 
 For more information about each of the different resources these are documented on the provider registry page: https://registry.terraform.io/providers/common-fate/commonfate/latest/docs
 
-The provider requires some variables for it to work with your deployment. All of these variables can be found from your deployment Terraforms outputs.
+The provider requires some variables for it to work with your deployment. All of these variables can be found from your deployment Terraform outputs.
 
 Our Terraform provider uses a machine-to-machine OpenID Connect (OIDC) protocol to authenticate to Common Fate. The AWS Cognito user pool deployed with Common Fate acts as the OIDC issuer.
 

--- a/config/workflows.mdx
+++ b/config/workflows.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Workflows"
-description: "This expains how to make workflows to be used in Common Fate."
+description: "This explains how to make workflows to be used in Common Fate."
 ---
 
 ## What are Access Workflows?

--- a/granted/internals/different-assumers.mdx
+++ b/granted/internals/different-assumers.mdx
@@ -13,7 +13,7 @@ Granted which is powered by [Go under the hood](https://github.com/common-fate/g
 ```go
 
 type Assumer interface {
-	// AssumeTerminal should follow the required process for it implemetation and return aws credentials ready to be exported to the terminal environment
+	// AssumeTerminal should follow the required process for it implementation and return aws credentials ready to be exported to the terminal environment
 	AssumeTerminal(context.Context, *Profile, ConfigOpts) (aws.Credentials, error)
 	// AssumeConsole should follow any console specific credentials processes, this may be the same as AssumeTerminal under the hood
 	AssumeConsole(context.Context, *Profile, ConfigOpts) (aws.Credentials, error)

--- a/granted/troubleshooting.mdx
+++ b/granted/troubleshooting.mdx
@@ -52,14 +52,14 @@ If you don't know which SSO region your AWS organization is in, you'll need to c
 
 Granted settings are in `~/.granted`. If your trying to find where a setting is coming from, also check these directories:
 
-* `~/.aws`
-* `~/.password-store`
-* `~/.gnupg`
-* `~/.local/share/keyrings`
+- `~/.aws`
+- `~/.password-store`
+- `~/.gnupg`
+- `~/.local/share/keyrings`
 
 ## gpg: decryption failed: no secret key
 
-If you are tyring to use `pass`, [make sure you followed the instructions](./recipes/pass.md). Note that `export GPG_TTY=$(tty)` must have been executed in the current shell so that you can be asked for your password.
+If you are trying to use `pass`, [make sure you followed the instructions](./recipes/pass.md). Note that `export GPG_TTY=$(tty)` must have been executed in the current shell so that you can be asked for your password.
 
 ## Granted stopped working (Windows)
 

--- a/granted/usage/console.mdx
+++ b/granted/usage/console.mdx
@@ -128,7 +128,7 @@ assume role-a -u
 
 ## Launching the console with existing credentials
 
-In some cases, you may want to launch a console using existing credentials. An example is to programatically invoke `granted` from another application where that application manages the credentials.
+In some cases, you may want to launch a console using existing credentials. An example is to programmatically invoke `granted` from another application where that application manages the credentials.
 
 The `granted console` command will read the credentials from the environment as below:
 

--- a/granted/usage/profile-registry.mdx
+++ b/granted/usage/profile-registry.mdx
@@ -166,9 +166,9 @@ templateValues:
       - prompt: "Enter your user name (e.g john.doe)"
 ```
 
-Templated values should be defined with `{{ .Required.KeyName}}` or `{{ .Variables.KeyName}}` to differentiate if they are user specific values or arbitary variables.
+Templated values should be defined with `{{ .Required.KeyName}}` or `{{ .Variables.KeyName}}` to differentiate if they are user specific values or arbitrary variables.
 
-Your corresponsing profiles might look like:
+Your corresponding profiles might look like:
 
 ```
 [profile dev]

--- a/granted/usage/storing-iam-credentials-securely.mdx
+++ b/granted/usage/storing-iam-credentials-securely.mdx
@@ -22,7 +22,7 @@ COMMANDS:
    help, h           Shows a list of commands or help for one command
 
 OPTIONS:
-   --help, -h  show help (default: false
+   --help, -h  show help (default: false)
 ```
 
 ## `add` command

--- a/integrations/iam-identity-center-groups.mdx
+++ b/integrations/iam-identity-center-groups.mdx
@@ -5,7 +5,7 @@ description: "Setup guide for using Common Fate to grant access to IAM Identity 
 
 This guide will walk you through integrating Common Fate with Amazon Web Services (AWS). By the end of this guide, you'll have a functioning integration with Common Fate, allowing it to grant temporary access to IAM Identity Center groups.
 
-## Prerequisities
+## Prerequisites
 
 Support for managing IAM Identity Center group assignments requires the following minimum software versions:
 

--- a/user-guide/cli/requesting-access.mdx
+++ b/user-guide/cli/requesting-access.mdx
@@ -108,7 +108,7 @@ For JSON output, use the `--output json` flag with respective commands.
 
 ### Approve Request
 
-If you have the Slack intgration connected, requests can be approved directly in Slack:
+If you have the Slack integration connected, requests can be approved directly in Slack:
 
 <img
   src="/images/end-user/slack-approve.png"


### PR DESCRIPTION
Turns out the only delta with https://github.com/common-fate/docs-new was some spelling mistake fixes since there were common commits to both `docs-new` and `docs`.

I have also fixed other spelling errors since I was already having a look.