### PR TITLE
removing reference to DynamoDB

### DIFF
--- a/setup/backups.mdx
+++ b/setup/backups.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Managing Backups"
-description: "This guide outlines the steps applying database backups for RDS and DynamoDB in Common Fate deployments."
+description: "This guide outlines the steps applying database backups for RDS in Common Fate deployments."
 ---
 
 ## **Prerequisites**
@@ -9,19 +9,24 @@ description: "This guide outlines the steps applying database backups for RDS an
 - Common Fate deployment Terraform version v1.38.0+
 - Access to the deployment account where Common Fate is deployed
 
-
 ## RDS Restore from backup
-In Common Fate version v1.38.0 and onwards we have introduced the support for RDS backups from within Terraform. With the introduction of the 
+
+In Common Fate version v1.38.0 and onwards we have introduced the support for RDS backups from within Terraform. With the introduction of the
 `restore_to_point_in_time` and `rds_db_retention_period` variables to the **Common Fate** deployment module to instruct the build to restore from a previous version of the RDS database.
 
 - By default the `rds_db_retention_period` will be 7 days, meaning you will be able to backup to any point in time in the last 7 days. This is also now configurable and can be increased up to 35 days.
 
-The `restore_to_point_in_time` variable mimics the variable used in the [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#restore-to-point-in-time) AWS Terraform resource. 
+The `restore_to_point_in_time` variable mimics the variable used in the [aws_db_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#restore-to-point-in-time) AWS Terraform resource.
 
-<Note>Restoring from a backup or a PITR backup will always result in the creation of a new table. To apply the restored table to your Common Fate deployment you will need to apply the restored table to the table created from the Terraform module</Note>
-
+<Note>
+  Restoring from a backup or a PITR backup will always result in the creation of
+  a new table. To apply the restored table to your Common Fate deployment you
+  will need to apply the restored table to the table created from the Terraform
+  module
+</Note>
 
 ### Example usage in Common Fate:
+
 ```
 resource "common-fate" {
       ...
@@ -33,20 +38,23 @@ resource "common-fate" {
           source_db_instance_identifier = "prod-db"
           source_dbi_resource_id        = null
           use_latest_restorable_time    = null
-        
+
         }]
 }
 ```
 
-### Process to restore from backup 
+### Process to restore from backup
+
 To process to restore from a backup in RDS is a 3 part process.
 First you will need to create a new database restore from a backup. Do do this you can pick any time that is within the db retention period and restore a backup from that. This should create a new instance of a RDS database which is restored from a PITR backup.
-This can be done in the AWS Cli or the AWS console. 
+This can be done in the AWS Cli or the AWS console.
+
 ### AWS CLI
 
 You will first need to find the name of your RDS table. To find it, head into the console and go to RDS then in the list of tables, choose the table created for the Common Fate deployment. It should be named like this: `<namespace>-<stage>-pg-db`
 
-Run the following command 
+Run the following command
+
 ```
 aws rds restore-db-instance-to-point-in-time \
     --source-db-instance-identifier <namespace>-<stage>-pg-db \
@@ -57,6 +65,7 @@ aws rds restore-db-instance-to-point-in-time \
 ```
 
 ### AWS Console
+
 1. Sign in to the AWS Management Console and open the Amazon RDS console at https://console.aws.amazon.com/rds/.
 
 2. In the navigation pane, choose Automated backups.
@@ -73,7 +82,11 @@ aws rds restore-db-instance-to-point-in-time \
 
 8. If you chose Custom, enter the date and time to which you want to restore the instance.
 
-<Note>Times are shown in your local time zone, which is indicated by an offset from Coordinated Universal Time (UTC). For example, UTC-5 is Eastern Standard Time/Central Daylight Time.</Note>
+<Note>
+  Times are shown in your local time zone, which is indicated by an offset from
+  Coordinated Universal Time (UTC). For example, UTC-5 is Eastern Standard
+  Time/Central Daylight Time.
+</Note>
 
 9. For DB instance identifier, enter the name of the target restored DB instance. The name must be unique. For example 'temp-commonfate-restore'
 
@@ -85,6 +98,7 @@ aws rds restore-db-instance-to-point-in-time \
 
 Once you have made the restore and it has successfully created. You can now update the Common Fate deployment with the RDS identifier of the DB you just created.
 To do this add the following to your Common Fate deployment Terraform:
+
 ```
 restore_to_point_in_time = {
      restore_time                             = "2024-04-03T16:40:31+11:00"
@@ -97,69 +111,12 @@ restore_to_point_in_time = {
 
 Then run `terraform apply`
 
-<Note>`source_db_instance_indentifier` or `source_dbi_resource_id` is required and either `restore_time` or `use_latest_restorable_time` must be used in conjunction to identify which PITR backup should be used.</Note>
-- This will cause a replacement of the database. This is why we made a replica during step one. 
+<Note>
+  `source_db_instance_indentifier` or `source_dbi_resource_id` is required and
+  either `restore_time` or `use_latest_restorable_time` must be used in
+  conjunction to identify which PITR backup should be used.
+</Note>
+- This will cause a replacement of the database. This is why we made a replica during
+step one.{" "}
 
 When completed confirm that the deployment is working and you can delete the replica created in step one.
-
-
-## DynamoDB Restore from backup
-
-By default with Common Fate `point_in_time_recovery` is enabled by default for DynamoDB. In the case where a rollback is required here are the instructions to do so.
-
-<Note>Restoring from a backup or a PITR backup will always result in the creation of a new table. To apply the restored table to your Common Fate deployment you will need to apply the restored table to the table created from the Terraform module</Note>
-
-### Via the console
-1. Sign in to the AWS Management Console and open the DynamoDB console at https://console.aws.amazon.com/dynamodb/.
-
-2. In the navigation pane on the left side of the console, choose Tables.
-
-3. In the list of tables, choose the table created for the Common Fate deployment. It should be named like this: `<namespace>-<stage>-dynamodb-table`
-
-4. On the Backups tab of the table, in the Point-in-time recovery (PITR) section, choose Restore.
-
-5. For the new table name, enter something unique and identifies that this will be a temporary table. `temp-commonfate-restore`
-
-<Note>This will create a new dynamo table called `temp-commonfate-restore` it will then be used to update the production table to the restore time</Note>
-
-<Note>You can restore the table to the same AWS Region or to a different Region from where the source table resides. You can also exclude secondary indexes from being created on the restored table. In addition, you can specify a different encryption mode.</Note>
-
-To confirm the restorable time, set the restore date and time to Earliest. Then choose Restore to start the restore process.
-
-The table that is being restored is shown with the status Restoring. After the restore process is finished, the status of the `temp-commonfate-restore` table changes to Active.
-
-
-
-### Via AWS CLI
-To create a restore of your DynamoDB table with the CLI run the following command with AWS credentials in your terminal
-```
-aws dynamodb restore-table-to-point-in-time \
-    --source-table-name <namespace>-<stage>-dynamodb-table \
-    --target-table-name temp-commonfate-restore \
-    --no-use-latest-restorable-time \
-    --restore-date-time 1519257118.0
-```
-
-or to get the latest possible restore time:
-```
-aws dynamodb restore-table-to-point-in-time \
-    --source-table-name <namespace>-<stage>-dynamodb-table \
-    --target-table-name temp-commonfate-restore \
-    --use-latest-restorable-time  
-```
-
-### Updating the Common Fate table with restored data
-
-Finally you can point the restored table to the table created by Common Fate by adding the following variables to your Terraform code
-
-```
-dynamodb_restore_date_time      = <optional_date_time> //cannot be used in conjunction with dynamodb_restore_to_latest_time
-dynamodb_restore_source_name    = "<name_of_restored_table_created_above>"
-dynamodb_restore_to_latest_time = true //cannot be used in conjunction with dynamodb_restore_date_time
-```
-
-Then `terraform apply` and it should create a new table with the data source being from the restored backup we made in the steps above. 
-
-Once the table has been recreated, confirm that the deployment is working and data has been restored on your deployment.
-
-Once confirmed the backup table made in the first step can be deleted.

--- a/setup/security.mdx
+++ b/setup/security.mdx
@@ -9,7 +9,7 @@ description: "Identity and Access Management is a critical aspect of cloud secur
 
 **Audit Trail Events:** Common Fate maintains a comprehensive audit trail, recording key events to facilitate tracking and analysis of system activities for security and compliance purposes.
 
-**Disaster Recovery:** Common Fate uses managed databases such as AWS RDS and DynamoDB, and supports point-in-time recovery.
+**Disaster Recovery:** Common Fate uses managed databases such as AWS RDS and supports point-in-time recovery.
 
 **Common Fate assigns roles to your existing users:** We adopt the principle of least privilege when developing integrations for Common Fate. Wherever possible, our integrations only have permission to assign roles to users, rather than creating new roles or users.
 


### PR DESCRIPTION
From [v2.0.0](http://localhost:3000/migration-guide/migration-guide#v2-0-0) We no longer use DynamoDB tables