### PR TITLE
Fix broken images

### DIFF
--- a/images/user/activate.png
+++ b/images/user/activate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a536a457bde8839e25dbe72d27244379173502b4119156db2f162fa1ddcb4ead
+size 114752

--- a/images/user/approve.png
+++ b/images/user/approve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae4c845123d55a1a73140352beae65e4d4492d70227daef27555b831b3e0b821
+size 109266

--- a/images/user/breakglass-activate.png
+++ b/images/user/breakglass-activate.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b061fc6f750f2cfb1c54a673696f3ebcdc4f1affd631092266cca2f9c6f90aa7
+size 81032

--- a/images/user/close.png
+++ b/images/user/close.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce234824f199b42bab9c1b102fc72141ce649aa405ef7d467745a452037091d3
+size 67258

--- a/images/user/extend.png
+++ b/images/user/extend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ea29cd832523defc01adaf708c484cf039b6f7d1b2b9cdd62b6fe452cfdae81
+size 119531

--- a/images/user/granted.png
+++ b/images/user/granted.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a95170e10c509ecca15a9fd5925c218215961eb56ddae50adfa4eb882c52a42
+size 101208

--- a/images/user/profile-registry.png
+++ b/images/user/profile-registry.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c804bc0ca3a90b36e554ea2383fe01207333d0362721032602ae75449245326f
+size 122666

--- a/images/user/request.png
+++ b/images/user/request.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f404ddc62d49bb0f284c0bfc94db9cc9767b252ba132ee736ee146ed5aa63407
+size 146223

--- a/images/user/review-request.png
+++ b/images/user/review-request.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfda91b90ff2fbdc03817f28f0be187e850e45de19ee9cf3cdb5df729607b563
+size 65676

--- a/images/user/select-role.png
+++ b/images/user/select-role.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efb80c15f867029d87b2662e1246df0dd5f4b7347422c5d06beb89ecb377d717
+size 65738

--- a/images/user/slack-approve.png
+++ b/images/user/slack-approve.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98ef84a16f4feeb5238df6a38815115fd1590ec23c99054433ff10d3667dc58c
+size 83445

--- a/images/user/slack-commands.png
+++ b/images/user/slack-commands.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:58ae85c807913faec06b594efc1a25f36d3249e536976fd2f5bc1220aaaeee11
+size 96317

--- a/images/user/slack-extend.png
+++ b/images/user/slack-extend.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad74eed81b530982d92689d9a4d30a2ec176a16538b8e47ebf81337aef378a8e
+size 83695

--- a/images/user/slack-integrations-list.png
+++ b/images/user/slack-integrations-list.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b02600d02b369b1c786c4bdcf570845346f891b9096b0abe65f5d3b23ef45e4a
+size 94808

--- a/images/user/slack-request.png
+++ b/images/user/slack-request.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b71fbe604aaeaec7881f6d8477370b3ff220c27586065c189b95a15eddf9f96
+size 146654

--- a/user-guide/cli/requesting-access.mdx
+++ b/user-guide/cli/requesting-access.mdx
@@ -88,7 +88,7 @@ For JSON output, use the `--output json` flag with respective commands.
 Navigate to your designated slack access channel, type `/access`, and select the Common Fate app.
 
 <img
-  src="/images/end-user/slack-commands.png"
+  src="/images/user/slack-commands.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -98,7 +98,7 @@ Press enter after typing `/access` and you will be navigated to a pop-up through
 you can select the resource type.
 
 <img
-  src="/images/end-user/slack-integrations-list.png"
+  src="/images/user/slack-integrations-list.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -117,7 +117,7 @@ A request access form will appear. Follow these steps:
 Click the "Approve" button to approve the request:
 
 <img
-  src="/images/end-user/slack-approve.png"
+  src="/images/user/slack-approve.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -132,7 +132,7 @@ Activation of approved access requests can only be done through the webapp.
 Click the "Extend" button to extend the request:
 
 <img
-  src="/images/end-user/slack-extend.png"
+  src="/images/user/slack-extend.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -149,7 +149,7 @@ Click the "Extend" button to extend the request:
 Click the "Close" button to close the request:
 
 <img
-  src="/images/end-user/slack-approve.png"
+  src="/images/user/slack-approve.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -162,7 +162,7 @@ Click the "Close" button to close the request:
 1. Navigate to the "Request" tab in the sidebar. Search for and select the target:
 
    <img
-     src="/images/end-user/request.png"
+     src="/images/user/request.png"
      style={{
        clipPath: "inset(1px 1px 1px 1px)",
      }}
@@ -171,7 +171,7 @@ Click the "Close" button to close the request:
 2. Select the desired role:
 
    <img
-     src="/images/end-user/select-role.png"
+     src="/images/user/select-role.png"
      style={{
        clipPath: "inset(1px 1px 1px 1px)",
      }}
@@ -179,7 +179,7 @@ Click the "Close" button to close the request:
 
 3. Review and provide the access reason. Click "Request Access":
    <img
-     src="/images/end-user/review-request.png"
+     src="/images/user/review-request.png"
      style={{
        clipPath: "inset(1px 1px 1px 1px)",
      }}
@@ -190,7 +190,7 @@ Click the "Close" button to close the request:
 Navigate to the Access tab in the sidebar, locate the request, and click Approve:
 
 <img
-  src="/images/end-user/approve.png"
+  src="/images/user/approve.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -201,7 +201,7 @@ Navigate to the Access tab in the sidebar, locate the request, and click Approve
 Navigate to the Access tab in the sidebar, locate the request, and click Activate:
 
 <img
-  src="/images/end-user/activate.png"
+  src="/images/user/activate.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -210,7 +210,7 @@ Navigate to the Access tab in the sidebar, locate the request, and click Activat
 If breakglass access is enabled, you can activate it by checking the confirmation box. Once confirmed, click the "Activate" button to proceed:
 
 <img
-  src="/images/end-user/breakglass-activate.png"
+  src="/images/user/breakglass-activate.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -221,7 +221,7 @@ If breakglass access is enabled, you can activate it by checking the confirmatio
 Navigate to the Access tab in the sidebar, locate the request, and click Extend:
 
 <img
-  src="/images/end-user/extend.png"
+  src="/images/user/extend.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}
@@ -238,7 +238,7 @@ Navigate to the Access tab in the sidebar, locate the request, and click Extend:
 Navigate to the Access tab in the sidebar, locate the request, and click Close:
 
 <img
-  src="/images/end-user/close.png"
+  src="/images/user/close.png"
   style={{
     clipPath: "inset(1px 1px 1px 1px)",
   }}


### PR DESCRIPTION
This PR fixes the broken images currently on docs:
![Screenshot 2024-07-31 at 3 50 01 PM](https://github.com/user-attachments/assets/eedd32c8-a13e-4d2f-a7d8-b8959b31b17f)

I think the LFS was duplicated for some reason:

```
calvinluy➜~/Git/docs(calvin/cf-3455-images-broken-for-docs)» git lfs dedup                                                                                            [15:31:31]
Success: images/cedar/cedar-actions-workflow-new.png (Size: 256641)
Success: images/end-user/activate.png (Size: 114752)
Success: images/end-user/approve.png (Size: 109266)
Success: images/end-user/breakglass-activate.png (Size: 81032)
Success: images/end-user/close.png (Size: 67258)
Success: images/end-user/extend.png (Size: 119531)
Success: images/end-user/granted.png (Size: 101208)
Success: images/end-user/profile-registry.png (Size: 122666)
Success: images/end-user/request.png (Size: 146223)
Success: images/end-user/review-request.png (Size: 65676)
Success: images/end-user/select-role.png (Size: 65738)
Success: images/end-user/slack-approve.png (Size: 83445)
Success: images/end-user/slack-commands.png (Size: 96317)
Success: images/end-user/slack-extend.png (Size: 83695)
Success: images/end-user/slack-integrations-list.png (Size: 94808)
Success: images/end-user/slack-request.png (Size: 146654)


Finished successfully.
  De-duplicated  size: 1754910 bytes
                count: 16
```

I'm planning to bring up a follow up PR to rename it back to end-user, and to also update the extend functionality to be accurate after https://github.com/common-fate/teams/pull/833

