### PR TITLE
remove requirement to specify provisioner config

### DIFF
--- a/integrations/auth0.mdx
+++ b/integrations/auth0.mdx
@@ -57,24 +57,6 @@ Apply the changes. If the apply succeeds, you should see the integration appear 
 
 ## Provisioning access to Auth0 Organizations
 
-To grant and revoke access to Auth0 Organizations, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-In default deployments, there is a provisioner builtin to the main stack which can be configured using blocks.
-
-To configure the builtin Provisioner for Auth0 Organizations, add the `provisioner_okta_config` config block as per the example below:
-
-```hcl
-module "common-fate-deployment" {
-  source = "common-fate/common-fate-deployment/aws"
-  version = "..."
-
-  provisioner_auth0_config = {
-    domain                    = "<your domain from above, e.g. dev-1ulors88vi7zjge6.us.auth0.com>"
-    client_id                 = "<your Client ID from above, e.g. ISQp0GiY0xcdODDdWRFnuh5Ypfm0XIa1>"
-    client_secret_secret_path = "/common-fate/prod/auth0-client-secret"
-  }
-}
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl

--- a/integrations/aws-resources.mdx
+++ b/integrations/aws-resources.mdx
@@ -86,29 +86,6 @@ If after 10 minutes you do not see resources appear, check the logs of the `comm
 
 ## Provisioning access to AWS Resources
 
-To grant and revoke access to AWS Resources, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-
-Add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-# config/main.tf (in the Config folder, see: https://github.com/common-fate/byoc-aws-starter-config/tree/main/config)
-
-resource "commonfate_webhook_provisioner" "aws" {
-  url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "AWS::Account"
-      role_type   = "AWS::DynamicRole"
-      belonging_to = {
-        type = "AWS::Organization"
-        id   = "<Your AWS Organization ID>"
-      }
-    },
-  ]
-}
-
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl
@@ -163,7 +140,7 @@ Users can access this role via the Common Fate web console by visiting their req
 
 # Cedar policies
 
-### Permit Access::Role::"Reader" access to S3 Buckets in a specific OU 
+### Permit Access::Role::"Reader" access to S3 Buckets in a specific OU
 
 ```
 permit (

--- a/integrations/aws.mdx
+++ b/integrations/aws.mdx
@@ -239,29 +239,6 @@ If after 10 minutes you do not see resources appear, check the logs of the `comm
 
 ## Provisioning access to AWS
 
-To grant and revoke access to AWS, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-
-Add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-# config/main.tf (in the Config folder, see: https://github.com/common-fate/byoc-aws-starter-config/tree/main/config)
-
-resource "commonfate_webhook_provisioner" "aws" {
-  url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "AWS::Account"
-      role_type   = "AWS::IDC::PermissionSet"
-      belonging_to = {
-        type = "AWS::Organization"
-        id   = "<Your AWS Organization ID>"
-      }
-    },
-  ]
-}
-
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl

--- a/integrations/datastax.mdx
+++ b/integrations/datastax.mdx
@@ -70,43 +70,6 @@ Apply the changes. If the apply succeeds, you should see the integration appear 
 
 ## Provisioning access to DataStax Roles
 
-To grant and revoke access to DataStax Roles, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-In default deployments, there is a provisioner builtin to the main stack which can be configured using blocks.
-
-To configure the builtin Provisioner for DataStax Roles, add the `provisioner_datastax_config` config block as per the example below:
-
-```hcl
-module "common-fate-deployment" {
-  source = "common-fate/common-fate-deployment/aws"
-  version = "1.22.0"
-
-  provisioner_datastax_config = {
-    organization_id           = "<Your DataStax Organization ID>"
-    api_key_secret_path       = "/common-fate/prod/datastax-api-key"
-  }
-}
-```
-
-To obtain your DataStax Organization ID, navigate to Settings. Your DataStax Organization ID will be in the URL, for example: https://astra.datastax.com/org/ffaab174-bfd8-4bcc-860d-6c760df53bc9/settings/tokens. `ffaab174-bfd8-4bcc-860d-6c760df53bc9` would be your DataStax Organization ID.
-
-You'll additionally need to add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-resource "commonfate_webhook_provisioner" "prod" {
- url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "DataStax::Organization"
-      role_type   = "DataStax::Role"
-      belonging_to = {
-        type = "DataStax::Organization"
-        id   = "<Your DataStax Organization ID>"
-      }
-    },
-  ]
-}
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl

--- a/integrations/entra.mdx
+++ b/integrations/entra.mdx
@@ -69,42 +69,6 @@ Apply the changes. If the apply succeeds, you should see the integration appear 
 
 ## Provisioning access to Entra Groups
 
-To grant and revoke access to Entra Groups, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-In default deployments, there is a provisioner builtin to the main stack which can be configured using blocks.
-
-To configure the builtin Provisioner for Entra Groups, add the `provisioner_entra_config` config block as per the example below:
-
-```hcl
-module "common-fate-deployment" {
-  source = "common-fate/common-fate-deployment/aws"
-  version = "1.22.0"
-
-  provisioner_entra_config = {
-    tenant_id                 = "<Your Entra tenant id>"
-    client_id                 = "<Your Entra client id>"
-    client_secret_secret_path = "/common-fate/prod/entra-client-secret"
-  }
-}
-```
-
-You'll additionally need to add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-resource "commonfate_webhook_provisioner" "prod" {
- url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "Entra::Group"
-      role_type   = "Entra::GroupRole"
-      belonging_to = {
-        type = "Entra::Tenant"
-        id   = "<Your Entra tenant id>"
-      }
-    },
-  ]
-}
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl

--- a/integrations/gcp.mdx
+++ b/integrations/gcp.mdx
@@ -169,36 +169,6 @@ If after 10 minutes you do not see resources appear, check the logs of the `comm
 
 ## Provisioning access to GCP
 
-To grant and revoke access to GCP, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-
-Add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-resource "commonfate_webhook_provisioner" "prod" {
- url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "GCP::Project"
-      role_type   = "GCP::Role"
-      belonging_to = {
-        type = "GCP::Organization"
-        id   = "organizations/123456789123"
-      }
-    },
-    {
-      target_type = "GCP::Folder"
-      role_type   = "GCP::Role"
-      belonging_to = {
-        type = "GCP::Organization"
-        id   = "organizations/123456789123"
-      }
-    },
-  ]
-}
-```
-
-## GCP project selectors
-
 To make GCP projects available for Just-In-Time (JIT) access you can add a `commonfate_gcp_project_selector` [Selector](/config/selectors) resource to your Common Fate application Terraform code. As shown below, the `when` clause in the resource is a [Cedar](https://cedarpolicy.com/) expression. You can use any [Cedar operator](https://docs.cedarpolicy.com/policies/syntax-operators.html) in the `when` clause, such as `&&` and `||` to combine conditions.
 
 You'll need to use the `commonfate_gcp_project_selector` in conjunction with a `commonfate_gcp_project_availabilities` and `commonfate_access_workflow` resources.

--- a/integrations/okta.mdx
+++ b/integrations/okta.mdx
@@ -49,41 +49,6 @@ Apply the changes. If the apply succeeds, you should see the integration appear 
 
 ## Provisioning access to Okta Groups
 
-To grant and revoke access to Okta Groups, Common Fate uses a service called the Provisioner. The Provisioner is an internal service and is not user-facing.
-In default deployments, there is a provisioner builtin to the main stack which can be configured using blocks.
-
-To configure the builtin Provisioner for Okta Groups, add the `provisioner_okta_config` config block as per the example below:
-
-```hcl
-module "common-fate-deployment" {
-  source = "common-fate/common-fate-deployment/aws"
-  version = "1.22.0"
-
-  provisioner_okta_config = {
-    organization_id           = "<Your Okta organization id>"
-    api_key_secret_path       = "/common-fate/prod/okta-api-key"
-  }
-}
-```
-
-You'll additionally need to add the following Provisioner registration inside your Application Configuration repository:
-
-```hcl
-resource "commonfate_webhook_provisioner" "prod" {
- url = "http://common-fate-prod-builtin-provisioner.common-fate-prod-builtin.internal:9999"
-  capabilities = [
-    {
-      target_type = "Okta::Group"
-      role_type   = "Okta::GroupRole"
-      belonging_to = {
-        type = "Okta::Organization"
-        id   = "<Your Okta organization id>"
-      }
-    },
-  ]
-}
-```
-
 You can now create an access workflow and availabilities:
 
 ```hcl


### PR DESCRIPTION
This is now no longer required in new versions of Common Fate.
